### PR TITLE
Remove cert of incorporation & exemption letter

### DIFF
--- a/docs/corporate-docs/README.md
+++ b/docs/corporate-docs/README.md
@@ -21,10 +21,8 @@ Current corporate Officers:
 Legal & governance documents:
 
 * [Bylaws](https://drive.google.com/file/d/0B15PjYEwl2GNMlNHZ0hXSnVZMDQ/view)
-* [Certificate of Incorporation](https://drive.google.com/file/d/0B15PjYEwl2GNYzVvWURteXZMM00/view)
 * [Organization statement (elects the board)](https://drive.google.com/file/d/0B15PjYEwl2GNUktDdjV5eEZXRVU/view)
 * [Written consent of initial board of directors (adopts bylaws and elects officers)](https://drive.google.com/file/d/0BzPWVMj9wWa6dFFZV2ZtUU9UM2s/view)
-* [IRS exemption determination letter](https://drive.google.com/file/d/0B15PjYEwl2GNY2JzT1JIblZpdnM/view)
 * [Corporate policies](https://drive.google.com/drive/folders/0B15PjYEwl2GNTzZYMWZULUdKa1E) (those adopted so far - more in progress)
 * Legal representation: [Nixon Peabody summary of engagement](https://docs.google.com/document/d/1FfLTCkzP1OfdgahDmlztjCIqAurYzwzkjgug5fXxjkM/view)
 * [Minutes of the Board of Directors](https://drive.google.com/drive/folders/0BzPWVMj9wWa6MVhCTGo5b1hwLVk?usp=sharing)


### PR DESCRIPTION
The more I think about it, the more I'm concerned that these 2 docs are the primary documents that are used to prove the organization's existence and open accounts in its name. I'm not 100% comfortable having them publicly viewable so that anyone could grab them and try to open an account or something. I'm open to leaving them if people don't agree but I wanted to raise the risk at least. We can always provide them if someone asks and has a reason for wanting to see them.