### PR TITLE
Update links and new text for monitoring funds

### DIFF
--- a/docs/monitoring-funds.md
+++ b/docs/monitoring-funds.md
@@ -1,9 +1,9 @@
 # Monitoring Your Funds
 
-In the [Master Accounting Bridge Foundry Financials](http://bit.ly/bridges-financials) we track financial information for Bridge Foundry and all of its Bridges and Chapters. This is where you find all of the latest information about money that comes in and money that goes out.  In general, this should be current for anything that is more than 2 weeks old.
+In the [Master Accounting Bridge Foundry Financials](https://docs.google.com/spreadsheets/d/1ImzwdUEd6j0jwDGW7fHS42qc739fh9LMOUmu_yggIO4/edit?usp=sharing) we track financial information for Bridge Foundry and all of its Bridges and Chapters. This is where you find all of the latest information about money that comes in and money that goes out.  In general, this should be current for anything that is more than 2 weeks old.
 
 In this spreadsheet, some of the tabs you will find are:
 
-* *[Org overview](https://docs.google.com/spreadsheets/d/10TzUid02hIkZTCjwKLI-c-OX5OeB2yergr71eHCc3uc/edit#gid=2079783535)*: A running tally of money in/money out and balance, as well as contact info, for each Bridge group.
-* *[Invoice status](https://docs.google.com/spreadsheets/d/10TzUid02hIkZTCjwKLI-c-OX5OeB2yergr71eHCc3uc/edit#gid=1195766135)*: Status of each invoice sent to sponsors.
+* *[Org overview](https://docs.google.com/spreadsheets/d/1ImzwdUEd6j0jwDGW7fHS42qc739fh9LMOUmu_yggIO4/edit#gid=1763745125)*: A running tally of money in/money out and balance, as well as contact info, for each Bridge group.
+* *Invoice status*: To check sponsor invoice payment status open the link in the e-mail and look for the paid stamp.
 * *Bridge & chapter funds*: Tabs with a running tally for each Bridge and Chapter. Please find your group in the tabs at the bottom of the spreadsheet. (Note: some Independent Communities that receive grants do not have their own tab.)


### PR DESCRIPTION
Diana noticed the links are pointing to the old location. Updated them.

Also, ideally, someone updates the `bit.ly/bridges-financials` link and we use that.