### PR TITLE
Update cash advance option to direct pay option

### DIFF
--- a/docs/grants/seed-grants.md
+++ b/docs/grants/seed-grants.md
@@ -23,7 +23,7 @@ If grant applications exceed current funding, Bridge Foundry staff will assess i
 ## Receiving & Using Funds
 Once the grant is approved, there are two ways to make use of the funds:
 1. **Reimbursement** (preferred): Make the purchases and submit your receipts for reimbursement. Expensify deposits the reimbursement straight into your bank account.
-2. **Cash Advance**: For those who can't afford to get reimbursed, we can send you the funds via check or PayPal. You will be required to submit your receipts within 7 days and send back any extra money you didn't use.
+2. **Direct pay**: For those who can't afford to get reimbursed, we can arrange to pay for expenses directly by processing payment for an invoice from them or calling them with credit card information. This option requires some lead time to make arrangements.
 
 Learn more about spending the money under [Using Funds](https://github.com/bridgefoundry/operations/tree/master/using-funds).
 


### PR DESCRIPTION
We originally were told that we couldn't do direct pay for grants to independent groups, but then it was clarified that would be okay. We had the direct pay option listed before we were really ready to implement because it seemed like that was the only way to help out groups who couldn't afford reimbursement. Since direct pay is okay after all and we want to hold off on implementing cash advances until we have a full policy in place, I'm submitting this change to list direct pay as an option instead of cash advance.