### PR TITLE
Update links in Grants overview

### DIFF
--- a/docs/grants/README.md
+++ b/docs/grants/README.md
@@ -8,4 +8,4 @@ In most cases, a [Volunteer Fundraiser](https://rebrand.ly/volunteer-fundraiser-
 In cases where you are unsuccessful in raising funds to support your workshop, you can still apply for a grant! We call these [Seed Fund Grants](https://github.com/bridgefoundry/operations/blob/master/grants/seed-grants.md) and they have their own approval process.
 
 ## Application
-In both cases, the process starts by filling out a [Grant Application](https://docs.google.com/a/ultrasaurus.com/forms/d/1npx6D7iFl6yx6kBVlYTOG1-PiWMsDiTx_TQWNri1WIk/viewform).
+In both cases, the process starts by filling out a [Grant Application](https://forms.gle/ikoVftWbnaTrncCt6).

--- a/docs/grants/README.md
+++ b/docs/grants/README.md
@@ -2,10 +2,10 @@
 Bridge Foundry is committed to providing financial support to anyone who wants to organize a workshop. Independent Communities are able to take advantage of this support by applying for a grant.
 
 ## Funded Grants
-In most cases, a [Volunteer Fundraiser](https://rebrand.ly/volunteer-fundraiser-policies) from your area solicits donations from local sponsors and then you can apply for a grant to receive those funds. We call these [Funded Grants](https://github.com/bridgefoundry/operations/blob/master/grants/funded-grants.md).
+In most cases, a [Volunteer Fundraiser](../roles/volunteer-fundraiser-policies.md) from your area solicits donations from local sponsors and then you can apply for a grant to receive those funds. We call these [Funded Grants](funded-grants.md).
 
 ## Seed Fund Grants
-In cases where you are unsuccessful in raising funds to support your workshop, you can still apply for a grant! We call these [Seed Fund Grants](https://github.com/bridgefoundry/operations/blob/master/grants/seed-grants.md) and they have their own approval process.
+In cases where you are unsuccessful in raising funds to support your workshop, you can still apply for a grant! We call these [Seed Fund Grants](seed-grants.md) and they have their own approval process.
 
 ## Application
 In both cases, the process starts by filling out a [Grant Application](https://forms.gle/ikoVftWbnaTrncCt6).


### PR DESCRIPTION
This PR updates all the links on the Grants overview page:

- replaces an outdated link to an old application form.
- uses relative links to for easier navigation within the same (commit) context - useful if we ever modify multiple files that rely on the same commit.

See individual commits for more information.