### PR TITLE
Set up GitHub Actions to build and deploy to GitHub Pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install mkdocs
+    - name: Deploy
+      env:
+        GITHUB_ACTOR: ${{ secrets.GITHUB_ACTOR }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_REPOSITORY: ${{ secrets.GITHUB_REPOSITORY }}
+      run: |
+        # set push info to the last commit's author
+        git config user.name "$(git --no-pager log --format=format:'%an' -n 1)"
+        git config user.email "$(git --no-pager log --format=format:'%ae' -n 1)"
+        git remote set-url --push origin https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git
+        mkdocs gh-deploy --verbose


### PR DESCRIPTION
MkDocs supports deployments to GitHub Pages via their `mkdoc gh-pages`
command. Combining this and the power of GitHub Actions, we can forego
Firebase, build + deploy through GitHub, and still have a working
operations site.

This commit will set up http://bridgefoundry.github.io/operations for us
automatically. More setup will be necessary to move over to our current
domain for the site.

**Working example:** https://mxie.github.io/operations/ via [`gh-pages` branch](https://github.com/mxie/operations/tree/gh-pages) on my fork.