### PR TITLE
Perform Firebase deploy in GitHub Actions

### DIFF
--- a/.github/workflows/firebase-ci.yml
+++ b/.github/workflows/firebase-ci.yml
@@ -1,0 +1,29 @@
+name: Firebase deploy
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install mkdocs
+      - name: Build docs
+        run: |
+          mkdocs build -d public
+      - name: Deploy
+        uses: w9jds/firebase-action@master
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+        with:
+          args: deploy --only hosting


### PR DESCRIPTION
In the spirit of https://github.com/bridgefoundry/operations/pull/86 , this moves part of our deploy process to GitHub Actions.

It does not yet move hosting to GitHub Pages. I like the idea of moving hosting, but in #86 I found there is more work to be done there.