### PR TITLE
Update deprecated keyword

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: Bridge Foundry Operations
 docs_dir: docs/
 repo_url: https://github.com/bridgefoundry/operations
 theme: 'readthedocs'
-pages:
+nav:
 - "Home": 'index.md'
 - "Services":
     - "Overview": 'services/README.md'


### PR DESCRIPTION
'Pages' is no longer supported by mkdocs in its newest version and we need to update to "nav"