### PR TITLE
Fix deploy and update README

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,4 +22,13 @@ jobs:
         python -m pip install --upgrade pip
         pip install mkdocs
     - name: Deploy
-      run: mkdocs gh-deploy --verbose --force
+      env:
+        GITHUB_ACTOR: ${{ github.actor }}
+        GITHUB_TOKEN: ${{ github.token }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+      run: |
+        # set push info to the last commit's author
+        git config user.name "$(git --no-pager log --format=format:'%an' -n 1)"
+        git config user.email "$(git --no-pager log --format=format:'%ae' -n 1)"
+        git remote set-url --push origin https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git
+        mkdocs gh-deploy --verbose --force

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,13 +22,4 @@ jobs:
         python -m pip install --upgrade pip
         pip install mkdocs
     - name: Deploy
-      env:
-        GITHUB_ACTOR: ${{ secrets.GITHUB_ACTOR }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GITHUB_REPOSITORY: ${{ secrets.GITHUB_REPOSITORY }}
-      run: |
-        # set push info to the last commit's author
-        git config user.name "$(git --no-pager log --format=format:'%an' -n 1)"
-        git config user.email "$(git --no-pager log --format=format:'%ae' -n 1)"
-        git remote set-url --push origin https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git
-        mkdocs gh-deploy --verbose
+      run: mkdocs gh-deploy --verbose --force

--- a/README.md
+++ b/README.md
@@ -13,15 +13,13 @@ For details about who runs our operations and writes this guide, see [CONTRIBUTI
 
 operations.bridgefoundry.org uses `mkdocs` to turn this git repository
 into well-formatted HTML. You can run `mkdocs` on your own computer to
-preview the site. We use Travis-CI to generate the site when the
-`master` branch updates; Travis-CI [stores its logs
-here.](https://travis-ci.org/bridgefoundry/operations) 
+preview the site.
 
-We use Firebase to serve the website to the world; talk to Sarah for access. Now and then we need to refresh the token:
+We use GitHub Actions to generate the site when the
+`main` branch updates; Build logs can be found
+[here](https://github.com/bridgefoundry/operations/actions/workflows/build.yml).
 
-1. if needed `npm install -g firebase-tools`
-2. `firebase login:ci`
-3. in [Travis Settings](https://travis-ci.org/bridgefoundry/operations/settings), deleted FIREBASE_TOKEN, add new one
+We use GitHub Pages to serve the website to the world.
 
 ## Running Locally
 To generate the nicely-formatted site on your own computer, open up a


### PR DESCRIPTION
This PR addresses the following:
- fixes deploy failures with `--force` option to deploy command
- changes how we fetch GitHub credentials and repo context within the workflow
- updates the README to reflect that we're using Actions and Pages to make the website

See individual commit messages for more info.