### PR TITLE
Replace specific references to PEX cards with "corporate cards"

### DIFF
--- a/docs/roles/README.md
+++ b/docs/roles/README.md
@@ -23,7 +23,7 @@ Most of the groups we work with are Independent Communities (usually referred to
 ## Chapter
 Chapters have a lot in common with Communities. They agree to our Workshop Guidelines and use a version of one of our official names. They can access the same resources like fundraising advice and use of [Bridge Troll](http://bridgetroll.org). They also have some additional benefits:
 
-* Access to finance infrastructure, such as Pex cards and online donation processing through their website
+* Access to finance infrastructure, such as corporate cards and online donation processing through their website
 * Access to the benefits of being part of a nonprofit organization, which can include things like discounts and access to some in-kind gifts
 * In the future, active Bridge Foundry Chapters will also be covered by our liability insurance, in the unlikely event that there’s some kind of legal action.
 

--- a/docs/roles/bridge-leader-policies.md
+++ b/docs/roles/bridge-leader-policies.md
@@ -16,8 +16,8 @@ As long as your Bridge remains active and works in a way that is consistent with
     * If the Bridge becomes inactive, we may seek out new leaders. When there are no leaders for a Bridge, we reserve the right to allocate the funds to other programs to support our mission.
 * Track financial transactions for your bridge in a location you can access to view history and bridge balance (currently via public spreadsheet)
 * Make it easy for your bridge leaders to spend funds available by:
-    * Providing a expense card for direct purchases to one bridge leader (currently via Pex)
-    * Providing reimbursements to all bridge leaders (currently via Expensify)
+    * Providing a expense card for direct purchases to one bridge leader
+    * Providing reimbursements to all bridge leaders
 * Facilitate access to discounts and benefits available via our non profit structure where possible
     * This is dependent on a) what we can practically support, and b) ensuring equal access for all bridges
     * In many cases this is as simple as providing our tax exemption letter so that a donor will make an in-kind donation or provide a discount

--- a/docs/roles/chapter-leader-policies.md
+++ b/docs/roles/chapter-leader-policies.md
@@ -16,8 +16,8 @@ As long as your Chapter remains active and works in a way that is consistent wit
     * If the chapter reverts to a Community Chapter, we reserve the right to allocate the funds elsewhere. AND, we will check in with you before that change to understand if you have workshops planned as a Community Chapter so we can use the remaining funds for a grant to the chapter. 
 * Track financial transactions for your chapter in a location you can access to view history and chapter balance (currently via public spreadsheet)
 * Make it easy for your chapter leaders to spend funds available to it by:
-    * Providing an expense card for direct purchases to one chapter leader (currently via Pex)
-    * Providing reimbursements to all chapter leaders (currently via Expensify)
+    * Providing an expense card for direct purchases to one chapter leader
+    * Providing reimbursements to all chapter leaders
 * Facilitate access to discounts and benefits available via our non profit structure where possible
     * This is dependent on a) what we can practically support, and b) ensuring equal access for all chapters
     * In many cases this is as simple as providing our tax exemption letter so that a donor will make an in-kind donation or provide a discount

--- a/docs/roles/program-leader-policies.md
+++ b/docs/roles/program-leader-policies.md
@@ -18,8 +18,8 @@ As long as your Program remains active and works in a way that is consistent wit
     * If the program becomes inactive, we reserve the right to allocate the funds elsewhere in support of our mission.
 * Track financial transactions for your program in a location you can access to view history and program balance (currently via public spreadsheet)
 * Make it easy for your program leaders to spend funds available to it by:
-    * Providing an expense card for direct purchases to one program leader (currently via Pex)
-    * Providing reimbursements to all program leaders (currently via Expensify)
+    * Providing an expense card for direct purchases to one program leader
+    * Providing reimbursements to all program leaders
 * Facilitate access to discounts and benefits available via our nonprofit structure where possible
     * This is dependent on a) what we can practically support, and b) ensuring equal access for all programs
     * In many cases this is as simple as providing our tax exemption letter so that a donor will make an in-kind donation or provide a discount

--- a/docs/school-factory/using-funds/README.md
+++ b/docs/school-factory/using-funds/README.md
@@ -12,8 +12,8 @@ Bridge Foundry is committed to supporting you in putting on your workshop, so yo
 ## Accessing funds
 Whether funds for a workshop were obtained via a sponsorship or through a Bridge Foundry grant, there are multiple ways to get access to your fund.
 
-### Pex Card
-You can use a [Pex Card](pex-cards.md) if you have or are eligible for one. Restrictions apply.
+### Corporate Card
+You can use a [corporate debit card](corporate-cards.md) if you have or are eligible for one. Restrictions apply.
 
 ### Working with vendors
 You can have vendors invoice Bridge Foundry directly. In fact, it is preferred.

--- a/docs/using-funds/README.md
+++ b/docs/using-funds/README.md
@@ -17,10 +17,10 @@ If you are working with an on-site service provider like a babysitter, print out
 ## Payment options
 
 ### Reimbursement
-Most volunteers get reimbursed via Expensify. The system allows you to submit your receipts and then receive a direct deposit reimbursement to your bank account.
+Volunteers can get reimbursed via Divvy. The system allows you to submit your receipts and then receive a direct deposit reimbursement to your bank account.  For more information, see [expense reports](expense-reports.md).
 
-### Pex Cards
-Chapter and Bridge Leaders (but not Independent Communities) have the option of applying for a prepaid cash card (Pex card), allowing them to pay directly from the funds they have raised through Bridge Foundry for expenses. They are required to submit receipts via Expensify by 5 days after month end for all expenses charged to the card.
+### Corporate Card
+Chapter and Bridge Leaders (but not Independent Communities) have the option of applying for a corporate debit card, allowing them to pay directly from the funds they have raised through Bridge Foundry for expenses. They are required to submit receipts via Divvy by 5 days after month end for all expenses charged to the card. Check out the [corporate cards](corporate-cards.md) page for more information.
 
 ### Direct Pay
-Chapters, Bridges, and Communities can also have Bridge Foundry pay directly from the funds they have raised through Bridge Foundry for expenses. This can be done via having the vendor bill us or sometimes we can call them with credit card information. This works best for payments that have at least a week lead time so we can make arrangements.
+Chapters, Bridges, and Communities can also have Bridge Foundry pay directly from the funds they have raised through Bridge Foundry for expenses. This can be done via having the vendor bill us or sometimes we can call them with credit card information. This works best for payments that have at least a week lead time so we can make arrangements. More information is available [here](direct-pay.md).

--- a/docs/using-funds/corporate-cards.md
+++ b/docs/using-funds/corporate-cards.md
@@ -1,6 +1,6 @@
 # PEX Card
 
-A Pex Card works as a debit card and it is designed to add greater flexibility and accessibility to funds for Chapter and Bridge Leaders. 
+A Pex Card works as a debit card and it is designed to add greater flexibility and accessibility to funds for Chapter and Bridge Leaders.
 
 Each card costs us $7.50/month, so we need to reserve these cards for active Chapters and Bridges. Signing an agreement as a Chapter Leader or Bridge Leader qualifies you for a Pex card, and we ask that if you only expect to charge expenses to it very rarely, you consider doing reimbursements or direct pay instead so we can keep these maintenance fees lower.
 
@@ -26,4 +26,4 @@ When you receive your card in the mail, contact finance@bridgefoundry.org to act
 - **Monitor your funds:** You can check your account balance by logging in here: https://ch.pexcard.com/  The balance on our master accounting spreadsheet reflects total available funds, including what is on your Pex card. It does not indicate how much is on the card. You must make a request for us to transfer funds to Pex.
 
 
-- **Reporting:** Be sure to submit an expense report every month that there are any charges on the card. The report is due within 5 days of the end of the month. Failure to submit an expense report on time or any misuse of funds may result in the revocation of PEX Card privileges.  
+- **Reporting:** Be sure to submit an expense report every month that there are any charges on the card. The report is due within 5 days of the end of the month. Failure to submit an expense report on time or any misuse of funds may result in the revocation of PEX Card privileges.

--- a/docs/using-funds/direct-pay.md
+++ b/docs/using-funds/direct-pay.md
@@ -14,7 +14,7 @@ finance@bridgefoundry.org
 Please [let us know](mailto:finance@bridgefoundry.org) if you expect a vendor to invoice us. The invoice from the vendor should also list your Chapter or Bridge name.
 
 ## Calling in Card Info
-In the rare circumstance that a Chapter or Bridge isn't able to use a Pex card or arrange for invoicing and can't afford to be reimbursed, we may be able to call your vendor with credit card information to arrange for faster payment. We do need advanced notice for this; allow a week but if you're in a jam reach out and we will do our best. Contact us at finance@bridgefoundry.org to inquire about this option.
+In the rare circumstance that a Chapter or Bridge isn't able to use a corporate card or arrange for invoicing and can't afford to be reimbursed, we may be able to call your vendor with credit card information to arrange for faster payment. We do need advanced notice for this; allow a week but if you're in a jam reach out and we will do our best. Contact us at finance@bridgefoundry.org to inquire about this option.
 
 ## Preferred vendors
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,7 +29,7 @@ nav:
     - "Approved expenses policy": 'using-funds/approved-expenses-policy.md'
     - "Direct pay": 'using-funds/direct-pay.md'
     - "Expense reports": 'using-funds/expense-reports.md'
-    - "Pex cards": 'using-funds/pex-cards.md'
+    - "Corporate cards": 'using-funds/corporate-cards.md'
 - "Monitoring funds": 'monitoring-funds.md'
 - "Internal process":
     - "Overview": 'internal-process/README.md'


### PR DESCRIPTION
We've replaced PEX with Divvy to provide corporate debit cards for our
leaders to pay for expenses. These changes are the first of many to
update our docs to reflect the new, all-in-one process for card usage
and expense reimbursement. Instead of referring to PEX specifically,
I've genericized the language to say "corporate cards" since that's what
they are. For now, the PEX Cards page will still have info on PEX until
that gets updated.
