### PR TITLE
Add sponsorship button to repo

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,5 @@
+# These are supported funding model platforms
+
+github: bridgefoundry
+open_collective: bridge-foundry-inc
+custom: ["https://paypal.me/bridgefoundry"]


### PR DESCRIPTION
It'll look something like this from the BridgeTroll repo

<img width="566" alt="bridge_troll: Event management system for all the Bridges (RailsBridge, MobileBridge, GoBridge, etc!) 2022-11-21 17-25-35" src="https://user-images.githubusercontent.com/602470/203170542-82d7cb1f-de2d-4976-acb6-dbbbb48df231.png">
