### PR TITLE
Update docs to reflect board decisions from minutes

### DIFF
--- a/docs/corporate-docs/README.md
+++ b/docs/corporate-docs/README.md
@@ -52,6 +52,10 @@ We keep information with Personally Identifiable Information (PII) private. Our 
 
 ## History
 
+- Desi McAdam, Chair 5/23/2022-12/7/2024
+- Desi McAdam, Secretary 8/15/2023-3/18/2025
+- Kinsey Durham Grace, Secretary 9/6/2022-8/15/2023
+- Sarah Allen, Secretary 5/23/2022-9/6/2022
 - Eggya Chiquita, Secretary 2/16/2020-2/13/2022
 - Ilen Zazueta-Hall, Chair 1/10/2018-12/31/2019
 - Karen Herreid, Treasurer

--- a/docs/corporate-docs/policy/README.md
+++ b/docs/corporate-docs/policy/README.md
@@ -2,3 +2,7 @@ Corporate Policies
 
 * [Gift Acceptance](gift-acceptance.md)
 * [General Signatory And Banking Authority Policy](signatory-and-banking.md)
+* [Annual Budget Reallocation](annual-budget-reallocation.md)
+* [Background Check Policy](background-check-policy.md)
+* [New Board Member Policy](new-board-member-policy.md)
+* [Board Member Agreement](../board-of-directors-minutes/2022-09-06-exhibit.md)

--- a/docs/corporate-docs/policy/annual-budget-reallocation.md
+++ b/docs/corporate-docs/policy/annual-budget-reallocation.md
@@ -1,0 +1,7 @@
+# Annual Budget Reallocation Policy
+
+*Adopted November 10, 2022*
+
+In January of each year, Bridge Foundry will adjust the budgets of any Bridges and Chapters such that a portion of their unused funds will be reallocated to support the work of smaller chapters and Bridges, as well as the broader work of Bridge Foundry.
+
+10% of the balance of each Bridge or Chapter will be transferred to the Bridge Foundry General Fund. However, any Bridge or Chapter leader who has specific plans for the use of those funds may request their budget be reserved for that use.

--- a/docs/corporate-docs/policy/new-board-member-policy.md
+++ b/docs/corporate-docs/policy/new-board-member-policy.md
@@ -2,4 +2,4 @@
 
 *Adopted October 29, 2024*
 
-New board members are reuqired to serve on a committee for at least three months and attend board meetings. The board may shorten this process if a candidate interviews with a majority of board members and has prior volunteer experience with Bridge Foundry.
+New board members are required to serve on a committee for at least three months and attend board meetings. The board may shorten this process if a candidate interviews with a majority of board members and has prior volunteer experience with Bridge Foundry.

--- a/docs/corporate-docs/policy/signatory-and-banking.md
+++ b/docs/corporate-docs/policy/signatory-and-banking.md
@@ -20,5 +20,7 @@ _General_
 
 Only the Board of Directors may delegate authority to incur expenses over **$5,000**.  Single expense transactions that exceed this threshold, or multiple transactions with a single third-party that exceed this threshold within a **three (3) month period**, shall also require majority approval by the Board of Directors.
 
+_Amendment adopted January 14, 2026:_ The Board of Directors delegates approval to the relevant Bridge or Program leader and one officer for specific Bridge or Program expenses above $5,000 (single transactions or as multiple transactions over a three-month period), which include expenses for multiple beneficiaries, such as scholarships to a conference, that are in support of our mission, provided that there are sufficient funds allocated to the specific Bridge or Program.
+
 Furthermore, if an authorized transaction requires a contract, only the CEO is authorized to sign on behalf of the organization.
 

--- a/docs/roles/bridge-leader-policies.md
+++ b/docs/roles/bridge-leader-policies.md
@@ -14,6 +14,7 @@ As long as your Bridge remains active and works in a way that is consistent with
     * If you want to raise funds in other ways, sign up as a Volunteer Fundraiser (separate agreement)
 * Hold funds raised for the Bridge in reserve for your Bridge’s use
     * If the Bridge becomes inactive, we may seek out new leaders. When there are no leaders for a Bridge, we reserve the right to allocate the funds to other programs to support our mission.
+    * Per the [Annual Budget Reallocation Policy](../corporate-docs/policy/annual-budget-reallocation.md), each January 10% of your Bridge's balance is transferred to the Bridge Foundry General Fund. Leaders with specific plans for their funds may request they be reserved.
 * Track financial transactions for your bridge in a location you can access to view history and bridge balance (currently via public spreadsheet)
 * Make it easy for your bridge leaders to spend funds available by:
     * Providing a expense card for direct purchases to one bridge leader

--- a/docs/roles/chapter-leader-policies.md
+++ b/docs/roles/chapter-leader-policies.md
@@ -13,7 +13,8 @@ As long as your Chapter remains active and works in a way that is consistent wit
 * Provide infrastructure for accepting online donations and send gift receipts 
     * If you want to raise funds in other ways, sign up as a Volunteer Fundraiser (separate agreement)
 * Hold funds raised for the chapter in reserve for your chapter’s sole use
-    * If the chapter reverts to a Community Chapter, we reserve the right to allocate the funds elsewhere. AND, we will check in with you before that change to understand if you have workshops planned as a Community Chapter so we can use the remaining funds for a grant to the chapter. 
+    * If the chapter reverts to a Community Chapter, we reserve the right to allocate the funds elsewhere. AND, we will check in with you before that change to understand if you have workshops planned as a Community Chapter so we can use the remaining funds for a grant to the chapter.
+    * Per the [Annual Budget Reallocation Policy](../corporate-docs/policy/annual-budget-reallocation.md), each January 10% of your chapter's balance is transferred to the Bridge Foundry General Fund. Leaders with specific plans for their funds may request they be reserved. 
 * Track financial transactions for your chapter in a location you can access to view history and chapter balance (currently via public spreadsheet)
 * Make it easy for your chapter leaders to spend funds available to it by:
     * Providing an expense card for direct purchases to one chapter leader


### PR DESCRIPTION
This PR updates operational docs and policies to reflect board decisions that were recorded in meeting minutes but not yet reflected in the documentation.

### Changes

- **Signatory & banking policy** — added Jan 2026 amendment delegating multi-beneficiary expense approval (e.g. conference scholarships) to the relevant Bridge/Program leader + one officer
- **Annual budget reallocation policy** — new policy file documenting the Nov 2022 resolution that 10% of each Bridge/Chapter balance is transferred annually to the General Fund
- **Bridge & chapter leader policies** — added references to the annual reallocation policy
- **Corporate policies index** — linked all policies (background check, new board member, board member agreement, annual reallocation) that were previously unlisted
- **Corporate docs history** — added missing Chair/Secretary transitions (2022–2025)
- Fixed typo in new board member policy