### PR TITLE
Update Divvy branding to BILL Spend & Expense

### DIFF
--- a/docs/grants/seed-grants.md
+++ b/docs/grants/seed-grants.md
@@ -24,7 +24,7 @@ If grant applications exceed current funding, Bridge Foundry staff will assess i
 ## Receiving & Using Funds
 Once the grant is approved, there are two ways to make use of the funds:
 
-1. **Reimbursement** (preferred): Make the purchases and submit your receipts for reimbursement. Divvy deposits the reimbursement straight into your bank account.
+1. **Reimbursement** (preferred): Make the purchases and submit your receipts for reimbursement. BILL Spend & Expense deposits the reimbursement straight into your bank account.
 2. **Direct pay**: For those who can't afford to get reimbursed, we can arrange to pay for expenses directly by processing payment for an invoice from them or calling them with credit card information. This option requires some lead time to make arrangements.
 
 Learn more about spending the money under [Using Funds](https://github.com/bridgefoundry/operations/tree/master/using-funds).

--- a/docs/using-funds/README.md
+++ b/docs/using-funds/README.md
@@ -17,10 +17,10 @@ If you are working with an on-site service provider like a babysitter, print out
 ## Payment options
 
 ### Reimbursement
-Volunteers can get reimbursed via Divvy. The system allows you to submit your receipts and then receive a direct deposit reimbursement to your bank account.  For more information, see [expense reports](expense-reports.md).
+Volunteers can get reimbursed via BILL Spend & Expense. The system allows you to submit your receipts and then receive a direct deposit reimbursement to your bank account.  For more information, see [expense reports](expense-reports.md).
 
 ### Corporate Card
-Chapter and Bridge Leaders (but not Independent Communities) have the option of applying for a corporate debit card, allowing them to pay directly from the funds they have raised through Bridge Foundry for expenses. They are required to submit receipts via Divvy by 5 days after month end for all expenses charged to the card. Check out the [corporate cards](corporate-cards.md) page for more information.
+Chapter and Bridge Leaders (but not Independent Communities) have the option of applying for a corporate debit card, allowing them to pay directly from the funds they have raised through Bridge Foundry for expenses. They are required to submit receipts via BILL Spend & Expense by 5 days after month end for all expenses charged to the card. Check out the [corporate cards](corporate-cards.md) page for more information.
 
 ### Direct Pay
 Chapters, Bridges, and Communities can also have Bridge Foundry pay directly from the funds they have raised through Bridge Foundry for expenses. This can be done via having the vendor bill us or sometimes we can call them with credit card information. This works best for payments that have at least a week lead time so we can make arrangements. More information is available [here](direct-pay.md).

--- a/docs/using-funds/corporate-cards.md
+++ b/docs/using-funds/corporate-cards.md
@@ -2,11 +2,11 @@
 
 Chapters, Bridges, and other programs that operate under Bridge Foundry can sign
 up to take advantage of our corporate cards program, which is managed through
-[Divvy]. These cards act like debit cards and are tied to the programs as
+[BILL Spend & Expense]. These cards act like debit cards and are tied to the programs as
 specified in the application. They are designed to add greater flexibility and
 accessibility to funds for our program leaders.
 
-[Divvy]: https://getdivvy.com/
+[BILL Spend & Expense]: https://www.bill.com/product/spend-and-expense
 
 ## Application Process
 
@@ -24,42 +24,42 @@ process this.
 
 ### Virtual Cards
 
-After you've set up your Divvy account, you will automatically have the ability
+After you've set up your BILL Spend & Expense account, you will automatically have the ability
 to create virtual cards. You can have as many of these as you'd like for your
-assigned budget(s) on Divvy. 
+assigned budget(s) on BILL Spend & Expense. 
 
 You can find out more about the different types of virtual cards and how to
 manage them in [this article][virtual cards overview].
 
-[virtual cards overview]: https://help.getdivvy.com/en/articles/2826509-virtual-cards-overview
+[virtual cards overview]: https://help.bill.com/direct/s/article/360021237411
 
 ### Physical Cards
 
 If you anticipate needing a physical card to make purchases, you may opt in to
 receive one when you fill out the application. If you opted out initially and
-change your mind later, you can order one through Divvy directly.
+change your mind later, you can order one through BILL Spend & Expense directly.
 
 It takes **7-14 business days** after processing the application to receive your
 card. You can also choose to pay $45 to expedite the the shipping to 4-6
 business days. This fee will be deducted from the Chapter or Bridge fund you're
 operating under.
 
-More about managing physical cards [here](https://help.getdivvy.com/en/collections/2467736-physical-cards).
+More about managing physical cards [here](https://help.bill.com/direct/s/article/8037759).
 
 #### Activation
 
-Once you receive your physical card, you can activate it on the Divvy website or
-mobile app. See this [Divvy help page][card activation] for instructions.
+Once you receive your physical card, you can activate it on the BILL Spend & Expense website or
+mobile app. See this [BILL help page][card activation] for instructions.
 
-[card activation]: https://help.getdivvy.com/en/articles/3210756-how-do-i-activate-a-physical-card-in-divvy
+[card activation]: https://help.bill.com/direct/s/article/3210756
 
 ## Use Guidelines
 
-- **Monitor your Divvy budget:** You can check your card and budget balances by
-logging into [Divvy](https://app.divvy.co/). The budgets on Divvy are set based 
+- **Monitor your BILL Spend & Expense budget:** You can check your card and budget balances by
+logging into [BILL Spend & Expense](https://spend.bill.com/). The budgets on BILL Spend & Expense are set based 
 on an estimate of how much you'll be spending on a monthly basis. This amount
 will never be higher than your total available funds. If you need to increase
-your budget, please use the ["Request Funds" feature][request funds] on Divvy or
+your budget, please use the ["Request Funds" feature][request funds] on BILL Spend & Expense or
 reach out to finance@bridgefoundry.org.
 
 - **Monitor your overall funds:** The balance on our [master accounting
@@ -67,10 +67,10 @@ spreadsheet] reflects total available funds, including what is on your card. It
 does not indicate how much is on the card. 
 
 - **Save all receipts:** All charges made on your card(s) must be reconciled on
-Divvy before the end of the month of when the expense incurred. Transaction
+BILL Spend & Expense before the end of the month of when the expense incurred. Transaction
 details must also include a copy of the receipt. Failure to complete transaction
 details on time or  any misuse of funds may result in the revocation of card
 privileges.
 
-[request funds]: https://help.getdivvy.com/en/articles/1963018-how-do-i-request-funds-as-a-budget-member-in-divvy
+[request funds]: https://help.bill.com/direct/s/article/1963018
 [master accounting spreadsheet]: https://docs.google.com/spreadsheets/d/1ImzwdUEd6j0jwDGW7fHS42qc739fh9LMOUmu_yggIO4/edit?usp=sharing


### PR DESCRIPTION
Divvy is now BILL's Spend & Expense product. This updates all references across the docs:

- Rename "Divvy" to "BILL Spend & Expense" for the platform
- Replace `getdivvy.com` with `bill.com/product/spend-and-expense`
- Replace `app.divvy.co` with `spend.bill.com`
- Replace dead `help.getdivvy.com` links with BILL help center article URLs

### Files changed
- `docs/using-funds/corporate-cards.md` — bulk of the changes (15 replacements + 4 updated help URLs)
- `docs/using-funds/README.md` — 2 references updated
- `docs/grants/seed-grants.md` — 1 reference updated

### Note
The `docs/using-funds/expense-reports.md` page referenced from `README.md` and `mkdocs.yml` doesn't exist — this is a pre-existing broken link (not introduced by this PR). A follow-up could create that page describing the BILL Spend & Expense reimbursement workflow.